### PR TITLE
Optimize Pyodide

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@fontsource-variable/fira-code": "^5.1.0",
     "@iconify/json": "^2.2.252",
     "@neodrag/svelte": "^2.0.6",
+    "@promplate/pyodide-bootstrap": "0.26.2",
     "@shikijs/monaco": "^1.18.0",
     "@shikijs/rehype": "^1.18.0",
     "@sveltejs/adapter-auto": "^3.2.5",
@@ -36,7 +37,6 @@
     "monaco-editor-core": "^0.52.0",
     "openai": "^4.63.0",
     "paneforge": "^0.0.6",
-    "pyodide": "0.26.2",
     "rehype-parse": "^9.0.0",
     "rehype-remark": "^10.0.0",
     "rehype-stringify": "^10.0.0",
@@ -67,6 +67,7 @@
     "eslint": "^9.11.1",
     "eslint-plugin-format": "^0.1.2",
     "eslint-plugin-svelte": "^2.44.0",
+    "pyodide": "0.26.2",
     "svelte-check": "^4.0.2"
   }
 }

--- a/src/lib/pyodide/common.ts
+++ b/src/lib/pyodide/common.ts
@@ -1,5 +1,5 @@
+import { version } from "@promplate/pyodide-bootstrap/version";
 import * as env from "$env/static/public";
-import { version } from "pyodide/package.json";
 
 // eslint-disable-next-line ts/ban-ts-comment
 // @ts-ignore

--- a/src/lib/pyodide/start/init.ts
+++ b/src/lib/pyodide/start/init.ts
@@ -11,7 +11,7 @@ import { withToast } from "$lib/utils/toast";
 import { toast } from "svelte-sonner";
 
 const getMinimalPyodide = cacheSingleton(withToast({ loading: "加载 Pyodide 运行时" })(async () => {
-  const { loadPyodide } = await import("pyodide");
+  const { loadPyodide } = await import("@promplate/pyodide-bootstrap");
   const py = await loadPyodide({ indexURL, env: getEnv(), packages: preloadPackages, args: dev ? [] : ["-O"] });
   py.globals.set("toast", toast);
   py.globals.set("async_input", (prompt: string) => input(prompt) ?? "");


### PR DESCRIPTION
## Motivation

本来是想部署到 Vercel Edge Function，但是可能是因为代码中有对 `node:...` 的动态 import，导致部署失败

## Description

于是我重构了 `pyodide`，从中删去了所有对 `node:*` 的 import，然后也把相关的对非浏览器 runtime 的支持都删了，顺便也简化了 build 的过程

## Result

- [x] 打包后 pyodide 的 chunk 减小了 45.1%
![image](https://github.com/user-attachments/assets/24303cdd-1b6b-4baf-ac2d-61cfdf0d4621)
![image](https://github.com/user-attachments/assets/479c0b6a-ef6a-4556-a792-41535458dff1)
- [x] No more false-positive warnings
```diff
- [plugin:vite:resolve] [plugin vite:resolve] Module "node:url" has been externalized for browser compatibility, imported by "/vercel/path0/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
- [plugin:vite:resolve] [plugin vite:resolve] Module "node:fs" has been externalized for browser compatibility, imported by "/vercel/path0/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
- [plugin:vite:resolve] [plugin vite:resolve] Module "node:fs/promises" has been externalized for browser compatibility, imported by "/vercel/path0/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
- [plugin:vite:resolve] [plugin vite:resolve] Module "node:vm" has been externalized for browser compatibility, imported by "/vercel/path0/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
- [plugin:vite:resolve] [plugin vite:resolve] Module "node:path" has been externalized for browser compatibility, imported by "/vercel/path0/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
- [plugin:vite:resolve] [plugin vite:resolve] Module "node:crypto" has been externalized for browser compatibility, imported by "/vercel/path0/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
- [plugin:vite:resolve] [plugin vite:resolve] Module "node:child_process" has been externalized for browser compatibility, imported by "/vercel/path0/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
- [plugin:vite:resolve] [plugin vite:resolve] Module "node:path" has been externalized for browser compatibility, imported by "/vercel/path0/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
- [plugin:vite:resolve] [plugin vite:resolve] Module "node:url" has been externalized for browser compatibility, imported by "/vercel/path0/node_modules/pyodide/pyodide.mjs". See https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
```
- [x] npm 上包大小从 14 MB 降到了 303 KB
- [ ] 大概是由于项目本身的原因，打包之后 Edge Function 超过了 1MB（大约 1.7 MB 的样子），所有还是不能部署到 edge